### PR TITLE
#6: Add nvim-tree support

### DIFF
--- a/after/plugin/nvim-tree.lua
+++ b/after/plugin/nvim-tree.lua
@@ -1,0 +1,4 @@
+local tree = require("nvim-tree")
+
+tree.setup()
+

--- a/lua/guava/keymaps.lua
+++ b/lua/guava/keymaps.lua
@@ -3,7 +3,7 @@
 vim.g.mapleader = " "
 
 -- Netrw
-vim.keymap.set("n", "<leader>pv", vim.cmd.Ex)
+vim.keymap.set("n", "<leader>pv", ":NvimTreeToggle<CR>")
 
 -- Save buffer
 vim.keymap.set("n", "<leader>w", vim.cmd.w)

--- a/lua/guava/options.lua
+++ b/lua/guava/options.lua
@@ -39,3 +39,7 @@ vim.api.nvim_create_autocmd("FileType", {
         vim.opt.formatoptions:remove({ "c", "r", "o" })
     end,
 })
+
+-- disable netrw in favor of nvim tree
+vim.g.loaded_netrw = 1
+vim.g.loaded_netrwPlugin = 1

--- a/lua/guava/packer.lua
+++ b/lua/guava/packer.lua
@@ -21,7 +21,7 @@ return packer.startup(function(use)
     })
 
     -- Colorscheme
-    use({ "navarasu/onedark.nvim"})
+    use({ "navarasu/onedark.nvim" })
 
     -- Treesitter: Advanced Syntax Highlighting
     use({ "nvim-treesitter/nvim-treesitter", run = ":TSUpdate" })
@@ -100,4 +100,10 @@ return packer.startup(function(use)
 
     -- Web Dev Icons: Good Icons (Mostly for dap ui)
     use({ "nvim-tree/nvim-web-devicons" })
+
+    -- nvim-tree: File Explorer
+    use({
+        "nvim-tree/nvim-tree.lua",
+        tag = "nightly", -- optional, updated every week. (see issue #1193)
+    })
 end)

--- a/plugin/packer_compiled.lua
+++ b/plugin/packer_compiled.lua
@@ -196,6 +196,11 @@ _G.packer_plugins = {
     path = "/Users/mikey/.local/share/nvim/site/pack/packer/start/nvim-lspconfig",
     url = "https://github.com/neovim/nvim-lspconfig"
   },
+  ["nvim-tree.lua"] = {
+    loaded = true,
+    path = "/Users/mikey/.local/share/nvim/site/pack/packer/start/nvim-tree.lua",
+    url = "https://github.com/nvim-tree/nvim-tree.lua"
+  },
   ["nvim-treesitter"] = {
     loaded = true,
     path = "/Users/mikey/.local/share/nvim/site/pack/packer/start/nvim-treesitter",


### PR DESCRIPTION
Resolves #6. Removes support for netrw default in favor of nvim-tree.